### PR TITLE
Use debian bullseye instead of bookworm as base.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bookworm
+FROM debian:bullseye
 
 RUN apt-get update && apt-get install -y git build-essential autoconf libtool pkg-config gcc libgstrtspserver-1.0-dev libglib2.0-dev libgstreamer1.0-dev gstreamer1.0-plugins-ugly cmake curl zip unzip tar
 


### PR DESCRIPTION
When using debian bookworm as base the syscall epoll_pwait2 is used if the container is built on a system which has that system call available. But when the container is run on a system which does not have epoll_pwait2 then the container fails. This is the container version of the libc version issue which has been around forever Now the versioning issue has changed from the libc symbols to available system calls when the program is being run.