### PR TITLE
sc-4605: fix RTSP TCP-interleaved transport so HEVC IPC cameras stream

### DIFF
--- a/src/modules/rtsp-client/rtsp_client.cpp
+++ b/src/modules/rtsp-client/rtsp_client.cpp
@@ -311,6 +311,18 @@ void RtspClient::setupRtsp() {
         return resolveStart("Failed to set Authorization Digest header");
     }
 
+    // SC-4605: install the interleave callback BEFORE PLAY. Many embedded
+    // RTSP servers (e.g. dolphin-rtsp-server on cheap IPC cameras) start
+    // pushing interleaved RTP frames in the same send() as the PLAY
+    // response. With no INTERLEAVEFUNCTION installed, those bytes land in
+    // libcurl's body buffer and the connection state desyncs, causing the
+    // next CURL_RTSPREQ_RECEIVE to error with CURLE_RECV_ERROR.
+    if (tcpClient_ != nullptr) {
+        if (!tcpClient_->prepareInterleave()) {
+            return resolveStart("Failed to install RTSP interleave callback");
+        }
+    }
+
     uint16_t status = 0;
     curl_->reinvokeStatus(&res, &status);
     if (res != CURLE_OK || status > 299) {
@@ -454,8 +466,24 @@ std::string RtspClient::parseControlAttribute(const std::string& att)
         return url;
     }
     else {
-        // is relative URL
-        return contentBase_ + url;
+        // is relative URL. RFC 2326 C.1.1 says to resolve against
+        // Content-Base. Strict RFC 3986 would replace the last segment of
+        // contentBase_, but in practice all working RTSP clients
+        // (VLC, ffmpeg, gst-launch) treat Content-Base as a directory and
+        // append, so SETUP URLs look like
+        // "rtsp://host/live/main/trackID=0" rather than
+        // "rtsp://host/live/trackID=0". Match that, which also means we
+        // must ensure a separating slash. Content-Base without trailing
+        // slash + bare "trackID=0" was previously concatenating into
+        // "...maintrackID=0", which dolphin-rtsp-server (and probably
+        // others) accept with 200 OK but then never start streaming on,
+        // because the SETUP didn't actually identify a known track.
+        // SC-4605.
+        std::string base = contentBase_;
+        if (!base.empty() && base.back() != '/') {
+            base += '/';
+        }
+        return base + url;
     }
 
 }

--- a/src/modules/rtsp-client/rtsp_client.cpp
+++ b/src/modules/rtsp-client/rtsp_client.cpp
@@ -210,7 +210,9 @@ bool RtspClient::start(std::function<void(std::optional<std::string> error)> cb)
     return curl_->asyncInvoke([self](CURLcode res, uint16_t statusCode) {
         if (res != CURLE_OK || statusCode > 299) {
             NPLOGE << "Failed to perform RTSP OPTIONS request: " << curl_easy_strerror(res);
-            std::string msg = res != CURLE_OK ? "Failed to send Options Request" : ("RTSP OPTIONS request failed with status code: " + statusCode);
+            std::string msg = res != CURLE_OK
+                ? "Failed to send Options Request"
+                : std::string("RTSP OPTIONS request failed with status code: ") + std::to_string(statusCode);
             return self->resolveStart(msg);
         }
         NPLOGD << "Options request complete " << curl_easy_strerror(res) << " " << statusCode;
@@ -327,7 +329,9 @@ void RtspClient::setupRtsp() {
     curl_->reinvokeStatus(&res, &status);
     if (res != CURLE_OK || status > 299) {
         NPLOGE << "Failed to perform RTSP PLAY request with: " << curl_easy_strerror(res);
-        std::string msg = res != CURLE_OK ? "Failed to send PLAY Request" : ("RTSP PLAY request failed with status code: " + status);
+        std::string msg = res != CURLE_OK
+            ? "Failed to send PLAY Request"
+            : std::string("RTSP PLAY request failed with status code: ") + std::to_string(status);
         return resolveStart(msg);
     }
 

--- a/src/modules/rtsp-client/rtsp_client.cpp
+++ b/src/modules/rtsp-client/rtsp_client.cpp
@@ -484,7 +484,7 @@ std::string RtspClient::parseControlAttribute(const std::string& att)
         // because the SETUP didn't actually identify a known track.
         // SC-4605.
         std::string base = contentBase_;
-        if (!base.empty() && base.back() != '/') {
+        if (!base.empty() && base.back() != '/' && url.front() != '/') {
             base += '/';
         }
         return base + url;

--- a/src/modules/rtsp-client/tcp_rtp_client.cpp
+++ b/src/modules/rtsp-client/tcp_rtp_client.cpp
@@ -1,6 +1,14 @@
 #include "tcp_rtp_client.hpp"
 #include <curl/curl.h>
 
+#include <arpa/inet.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <sys/socket.h>
+#include <sys/time.h>
+#include <errno.h>
+#include <cstring>
+
 namespace nabto {
 
 TcpRtpClientPtr TcpRtpClient::create(const TcpRtpClientConf& conf)
@@ -54,6 +62,19 @@ void TcpRtpClient::setConnection(NabtoDeviceConnectionRef ref, MediaTrackPtr vid
     }
 }
 
+bool TcpRtpClient::prepareInterleave()
+{
+    auto curl = curl_->getCurl();
+    CURLcode res = CURLE_OK;
+    if ((res = curl_easy_setopt(curl, CURLOPT_INTERLEAVEFUNCTION, &TcpRtpClient::rtp_write)) != CURLE_OK ||
+        (res = curl_easy_setopt(curl, CURLOPT_INTERLEAVEDATA, this)) != CURLE_OK) {
+        NPLOGE << "Failed to install interleave callback: " << curl_easy_strerror(res);
+        return false;
+    }
+    NPLOGD << "TcpRtpClient::prepareInterleave OK";
+    return true;
+}
+
 void TcpRtpClient::run()
 {
     NPLOGD << "TcpRtpClient run";
@@ -63,7 +84,53 @@ void TcpRtpClient::run()
     }
 
     auto curl = curl_->getCurl();
-    CURLcode res = CURLE_OK;
+
+    // CURL_RTSPREQ_RECEIVE is the wrong primitive for continuous
+    // interleaved RTP: libcurl's perform() waits for a server-side RTSP
+    // response message that never arrives from streaming servers like
+    // dolphin-rtsp-server, so the loop hangs at iter=1 with
+    // INTERLEAVEFUNCTION never invoked (SC-4605).
+    //
+    // After PLAY succeeded the TCP socket is fully ours. Read it directly,
+    // run the bytes through the same framer used by INTERLEAVEFUNCTION,
+    // and let the existing RTCP RR write() path remain. This is the same
+    // technique the RTCP-RR send code has been using already; we extend
+    // it to the read side too. The INTERLEAVEFUNCTION installed by
+    // prepareInterleave stays in place as a safety net in case any
+    // pre-PLAY/early bytes happened to be delivered through it.
+    curl_socket_t sockfd = CURL_SOCKET_BAD;
+    CURLcode infoRes = curl_easy_getinfo(curl, CURLINFO_ACTIVESOCKET, &sockfd);
+    if (infoRes != CURLE_OK || sockfd == CURL_SOCKET_BAD) {
+        NPLOGE << "TcpRtpClient: cannot get active socket: "
+               << curl_easy_strerror(infoRes) << " sock=" << sockfd;
+        return;
+    }
+    NPLOGD << "TcpRtpClient run sockfd=" << sockfd;
+
+    // libcurl leaves the socket in O_NONBLOCK; SO_RCVTIMEO is ignored on
+    // non-blocking sockets and recv() returns EAGAIN immediately, hot-spinning
+    // the loop (thousands of timeouts per second). Switch to blocking I/O
+    // so SO_RCVTIMEO actually drives the wait.
+    int flags = fcntl(sockfd, F_GETFL, 0);
+    if (flags == -1) {
+        NPLOGE << "fcntl(F_GETFL) failed: " << strerror(errno);
+    } else if ((flags & O_NONBLOCK) &&
+               fcntl(sockfd, F_SETFL, flags & ~O_NONBLOCK) == -1) {
+        NPLOGE << "fcntl(F_SETFL ~O_NONBLOCK) failed: " << strerror(errno);
+    }
+
+    // SO_RCVTIMEO lets recv() return periodically so we can check stopped_
+    // and act on pending RTCP without polling.
+    struct timeval tv;
+    tv.tv_sec = 0;
+    tv.tv_usec = 500 * 1000;  // 500 ms
+    if (setsockopt(sockfd, SOL_SOCKET, SO_RCVTIMEO,
+                   reinterpret_cast<const char*>(&tv), sizeof(tv)) < 0) {
+        NPLOGE << "setsockopt(SO_RCVTIMEO) failed: " << strerror(errno);
+        // Non-fatal; recv would just block longer.
+    }
+
+    uint8_t buf[8192];
     while (1) {
         {
             std::lock_guard<std::mutex> lock(mutex_);
@@ -72,43 +139,52 @@ void TcpRtpClient::run()
                 break;
             }
         }
-        if ((res = curl_easy_setopt(curl, CURLOPT_INTERLEAVEFUNCTION, &TcpRtpClient::rtp_write)) != CURLE_OK ||
-        (res = curl_easy_setopt(curl, CURLOPT_INTERLEAVEDATA, this)) != CURLE_OK ||
-        (res = curl_easy_setopt(curl, CURLOPT_RTSP_REQUEST, (long)CURL_RTSPREQ_RECEIVE)) != CURLE_OK) {
-            NPLOGE << "Failed to create RECEIVE request with: " << curl_easy_strerror(res);
-            break;
-        }
 
-        uint16_t status = 0;
-        curl_->reinvokeStatus(&res, &status);
-
-        if (res != CURLE_OK) {
-            NPLOGE << "Failed to perform RTSP RECEIVE request with: " << curl_easy_strerror(res);
-            break;
-        }
-
-        std::lock_guard<std::mutex> lock(mutex_);
-        if (sendRtcp_) {
-            sendRtcp_ = false;
-            CURLcode res = CURLE_OK;
-            curl_socket_t sockfd;
-            res = curl_easy_getinfo(curl, CURLINFO_ACTIVESOCKET, &sockfd);
-            if (!res && sockfd != CURL_SOCKET_BAD) {
-                uint16_t len = *(uint16_t*)(rtcpWriteBuf_+2)+4;
-                // NPLOGD << "Sending RR on channel: " << (int)rtcpWriteBuf_[1];
-                auto ret = write(sockfd, rtcpWriteBuf_, len);
-                if (ret < len) {
-                    NPLOGE << "Failed to write RTCP RR to TCP socket. ret: " << ret;
-                    break;
-                }
+        ssize_t n = ::recv(sockfd, buf, sizeof(buf), 0);
+        if (n < 0) {
+            const int err = errno;
+            if (err == EINTR || err == EAGAIN || err == EWOULDBLOCK) {
+                // SO_RCVTIMEO expired; loop and re-check stopped_.
             } else {
-                NPLOGE << "Failed to get active socket: " << curl_easy_strerror(res) << " Sock: " << sockfd;
-
+                NPLOGE << "TcpRtpClient recv failed: " << strerror(err);
+                break;
             }
+        } else if (n == 0) {
+            NPLOGE << "TcpRtpClient: peer closed TCP connection";
+            break;
+        } else {
+            processIncomingBytes(buf, static_cast<size_t>(n));
+        }
 
+        // Send any RTCP RR queued by drainInterleavedBuffer.
+        bool pendingRtcp = false;
+        size_t pendingRtcpLen = 0;
+        {
+            std::lock_guard<std::mutex> lock(mutex_);
+            if (sendRtcp_) {
+                sendRtcp_ = false;
+                pendingRtcp = true;
+                pendingRtcpLen = rtcpWriteLen_;
+            }
+        }
+        if (pendingRtcp) {
+            ssize_t ret = ::write(sockfd, rtcpWriteBuf_, pendingRtcpLen);
+            if (ret < 0 || (size_t)ret < pendingRtcpLen) {
+                NPLOGE << "Failed to write RTCP RR to TCP socket. ret: "
+                       << ret << " expected: " << pendingRtcpLen
+                       << " errno: " << strerror(errno);
+                break;
+            }
         }
     }
     NPLOGD << "TcpRtpClient run returning";
+}
+
+void TcpRtpClient::processIncomingBytes(const uint8_t* data, size_t len)
+{
+    std::lock_guard<std::mutex> lock(mutex_);
+    recvBuf_.insert(recvBuf_.end(), data, data + len);
+    drainInterleavedBuffer();
 }
 
 
@@ -116,60 +192,116 @@ size_t TcpRtpClient::rtp_write(void* ptr, size_t size, size_t nmemb, void* userp
 {
     TcpRtpClient* self = (TcpRtpClient*)userp;
     size_t len = size * nmemb;
-    if (len < 4) {
-        NPLOGE << "Received data len < 4 which should not be possible";
-        return len;
+    if (len == 0) {
+        return 0;
     }
 
-    if (((char*)ptr)[0] != '$') {
-        NPLOGE << "Received data did not start with $!";
-        return len;
+    // libcurl's CURLOPT_INTERLEAVEFUNCTION delivers raw bytes from the
+    // connection as they arrive: possibly a partial frame, possibly
+    // multiple frames concatenated, possibly leftover RTSP response chunks
+    // mixed with frame bytes. The previous implementation assumed one
+    // complete frame per call and silently dropped data on mismatch, which
+    // permanently desynced the libcurl RTSP state and caused
+    // CURLE_RECV_ERROR on the next RECEIVE. See SC-4605.
+    //
+    // Buffer everything, then loop and emit complete frames from the
+    // member buffer.
+    {
+        std::lock_guard<std::mutex> lock(self->mutex_);
+        const uint8_t* in = static_cast<const uint8_t*>(ptr);
+        self->recvBuf_.insert(self->recvBuf_.end(), in, in + len);
+        self->drainInterleavedBuffer();
     }
 
-    uint16_t dataLen = ((uint8_t*)ptr)[3] + (((uint8_t*)ptr)[2] << 8);
-    uint8_t channel = ((uint8_t*)ptr)[1];
-    // NPLOGE << "Received data on channel: " << (int)channel << " with len: " << len << " dataLen: " << dataLen;
-
-    if (channel == 0) {
-        // video RTP
-        std::lock_guard<std::mutex> lock(self->mutex_);
-        if (self->videoTrack_ != nullptr) {
-            uint8_t* buf = ((uint8_t*)ptr) + 4;
-            auto packets = self->videoRepacketizer_->handlePacket(std::vector<uint8_t>(buf, buf + dataLen));
-            for (auto p : packets) {
-                self->videoTrack_->send(p.data(), p.size());
-            }
-
-        }
-    } else if (channel == 2) {
-        // Audio RTP
-        std::lock_guard<std::mutex> lock(self->mutex_);
-        if (self->audioTrack_ != nullptr) {
-            uint8_t* buf = ((uint8_t*)ptr) + 4;
-            auto packets = self->audioRepacketizer_->handlePacket(std::vector<uint8_t>(buf, buf + dataLen));
-            for (auto p : packets) {
-                self->audioTrack_->send(p.data(), p.size());
-            }
-
-        }
-    } else {
-        std::lock_guard<std::mutex> lock(self->mutex_);
-        char* buffer = (char*)ptr + 4;
-        auto sr = reinterpret_cast<rtc::RtcpSr*>(buffer);
-        memset(self->rtcpWriteBuf_, 0, 64);
-        self->rtcpWriteBuf_[0] = '$';
-        self->rtcpWriteBuf_[1] = channel;
-        rtc::RtcpRr* rr = (rtc::RtcpRr*)(self->rtcpWriteBuf_ + 4);
-        rtc::RtcpReportBlock* rb = rr->getReportBlock(0);
-        rb->preparePacket(sr->senderSSRC(), 0, 0, 0, 0, 0, sr->ntpTimestamp(), 0);
-        rr->preparePacket(1, 1);
-        uint16_t* p = (uint16_t*)&self->rtcpWriteBuf_[2];
-        *p = rr->header.lengthInBytes();
-        self->sendRtcp_ = true;
-    }
-
-
+    // Always tell libcurl we consumed everything; we've buffered it.
     return len;
+}
+
+void TcpRtpClient::drainInterleavedBuffer()
+{
+    // mutex_ must be held by caller.
+    while (recvBuf_.size() >= 4) {
+        // Resync: skip any non-'$' bytes (interleaved framing starts with
+        // ASCII '$'). Avoid the previous behaviour of silently consuming
+        // data and then bailing; log it instead so misuse stands out.
+        size_t skipped = 0;
+        while (!recvBuf_.empty() && recvBuf_.front() != '$') {
+            recvBuf_.erase(recvBuf_.begin());
+            ++skipped;
+        }
+        if (skipped > 0) {
+            NPLOGE << "TcpRtpClient: skipped " << skipped
+                   << " non-frame bytes before next '$' (resync)";
+        }
+        if (recvBuf_.size() < 4) {
+            return;  // header not complete yet
+        }
+
+        const uint8_t channel = recvBuf_[1];
+        const uint16_t dataLen =
+            (static_cast<uint16_t>(recvBuf_[2]) << 8) |
+            static_cast<uint16_t>(recvBuf_[3]);
+        const size_t frameTotal = 4u + static_cast<size_t>(dataLen);
+
+        if (recvBuf_.size() < frameTotal) {
+            return;  // payload not complete yet
+        }
+
+        const uint8_t* payload = recvBuf_.data() + 4;
+
+        if (channel == 0) {
+            // Video RTP
+            if (videoTrack_ != nullptr) {
+                auto packets = videoRepacketizer_->handlePacket(
+                    std::vector<uint8_t>(payload, payload + dataLen));
+                for (auto& p : packets) {
+                    videoTrack_->send(p.data(), p.size());
+                }
+            }
+        } else if (channel == 2) {
+            // Audio RTP
+            if (audioTrack_ != nullptr) {
+                auto packets = audioRepacketizer_->handlePacket(
+                    std::vector<uint8_t>(payload, payload + dataLen));
+                for (auto& p : packets) {
+                    audioTrack_->send(p.data(), p.size());
+                }
+            }
+        } else {
+            // RTCP (channels 1 and 3: sender reports etc.). Build an RR
+            // in rtcpWriteBuf_; the outer loop in run() will write it after
+            // the current perform returns.
+            const char* buffer = reinterpret_cast<const char*>(payload);
+            auto sr = reinterpret_cast<const rtc::RtcpSr*>(buffer);
+
+            std::memset(rtcpWriteBuf_, 0, sizeof(rtcpWriteBuf_));
+            rtcpWriteBuf_[0] = '$';
+            rtcpWriteBuf_[1] = channel;
+
+            rtc::RtcpRr* rr = reinterpret_cast<rtc::RtcpRr*>(rtcpWriteBuf_ + 4);
+            rtc::RtcpReportBlock* rb = rr->getReportBlock(0);
+            rb->preparePacket(sr->senderSSRC(), 0, 0, 0, 0, 0, sr->ntpTimestamp(), 0);
+            rr->preparePacket(1, 1);
+
+            // RFC 2326 §10.12: the framing length field is in NETWORK
+            // byte order. The previous code wrote it host-order, which
+            // silently corrupted the frame on little-endian targets (i.e.
+            // every platform we ship on). See SC-4605.
+            const size_t rtcpBytes = rr->header.lengthInBytes();
+            uint16_t lenBe = htons(static_cast<uint16_t>(rtcpBytes));
+            std::memcpy(&rtcpWriteBuf_[2], &lenBe, sizeof(lenBe));
+            rtcpWriteLen_ = 4 + rtcpBytes;
+            if (rtcpWriteLen_ > sizeof(rtcpWriteBuf_)) {
+                NPLOGE << "RTCP RR overflows write buffer (" << rtcpWriteLen_
+                       << " > " << sizeof(rtcpWriteBuf_) << "); dropping";
+                rtcpWriteLen_ = 0;
+            } else {
+                sendRtcp_ = true;
+            }
+        }
+
+        recvBuf_.erase(recvBuf_.begin(), recvBuf_.begin() + frameTotal);
+    }
 }
 
 

--- a/src/modules/rtsp-client/tcp_rtp_client.cpp
+++ b/src/modules/rtsp-client/tcp_rtp_client.cpp
@@ -290,15 +290,18 @@ void TcpRtpClient::drainInterleavedBuffer()
             // in rtcpWriteBuf_; the outer loop in run() will write it after
             // the current perform returns.
             //
-            // Only build an RR from a sender report. Anything shorter than
-            // an SR header (or from a non-SR packet type) we skip without
-            // reading the payload; reinterpret_casting a too-short buffer
-            // and then reading senderSSRC()/ntpTimestamp() would be an
-            // out-of-bounds read.
-            if (dataLen < sizeof(rtc::RtcpSr)) {
-                NPLOGD << "TcpRtpClient: ignoring short RTCP frame on channel "
-                       << static_cast<int>(channel) << " (" << dataLen
-                       << " bytes)";
+            // Only build an RR from a Sender Report. Anything shorter than
+            // an SR header, or whose RTCP PT field (byte 1 of the RTCP
+            // header) is not 200 (SR), we skip without parsing the
+            // payload. The previous size-only check let an arbitrary
+            // RR/SDES/BYE/APP packet through; reading senderSSRC() and
+            // ntpTimestamp() out of those layouts produces meaningless
+            // values, and our RR response would carry garbage.
+            if (dataLen < sizeof(rtc::RtcpSr) || payload[1] != 200) {
+                NPLOGD << "TcpRtpClient: ignoring non-SR RTCP frame on channel "
+                       << static_cast<int>(channel)
+                       << " (pt=" << (dataLen >= 2 ? static_cast<int>(payload[1]) : -1)
+                       << " len=" << dataLen << ")";
                 recvBuf_.erase(recvBuf_.begin(),
                                recvBuf_.begin() + frameTotal);
                 continue;

--- a/src/modules/rtsp-client/tcp_rtp_client.cpp
+++ b/src/modules/rtsp-client/tcp_rtp_client.cpp
@@ -120,7 +120,10 @@ void TcpRtpClient::run()
     }
 
     // SO_RCVTIMEO lets recv() return periodically so we can check stopped_
-    // and act on pending RTCP without polling.
+    // and act on pending RTCP without polling. SO_SNDTIMEO bounds the
+    // RTCP RR write() below; if the camera's receive side stalls and our
+    // send buffer fills, an unbounded write would block this thread and
+    // stop() would hang waiting for stopped_ to be observed.
     struct timeval tv;
     tv.tv_sec = 0;
     tv.tv_usec = 500 * 1000;  // 500 ms
@@ -128,6 +131,11 @@ void TcpRtpClient::run()
                    reinterpret_cast<const char*>(&tv), sizeof(tv)) < 0) {
         NPLOGE << "setsockopt(SO_RCVTIMEO) failed: " << strerror(errno);
         // Non-fatal; recv would just block longer.
+    }
+    if (setsockopt(sockfd, SOL_SOCKET, SO_SNDTIMEO,
+                   reinterpret_cast<const char*>(&tv), sizeof(tv)) < 0) {
+        NPLOGE << "setsockopt(SO_SNDTIMEO) failed: " << strerror(errno);
+        // Non-fatal; RTCP RR write may block longer.
     }
 
     uint8_t buf[8192];
@@ -170,10 +178,13 @@ void TcpRtpClient::run()
         if (pendingRtcp) {
             ssize_t ret = ::write(sockfd, rtcpWriteBuf_, pendingRtcpLen);
             if (ret < 0 || (size_t)ret < pendingRtcpLen) {
-                NPLOGE << "Failed to write RTCP RR to TCP socket. ret: "
+                // RTCP RR is best-effort. A short write or transient
+                // EAGAIN/EINTR from SO_SNDTIMEO should not tear down the
+                // receive loop; if the connection is actually dead, recv()
+                // will surface it on the next iteration.
+                NPLOGE << "Failed to write RTCP RR to TCP socket; dropping. ret: "
                        << ret << " expected: " << pendingRtcpLen
                        << " errno: " << strerror(errno);
-                break;
             }
         }
     }
@@ -222,14 +233,21 @@ void TcpRtpClient::drainInterleavedBuffer()
     // mutex_ must be held by caller.
     while (recvBuf_.size() >= 4) {
         // Resync: skip any non-'$' bytes (interleaved framing starts with
-        // ASCII '$'). Avoid the previous behaviour of silently consuming
-        // data and then bailing; log it instead so misuse stands out.
-        size_t skipped = 0;
-        while (!recvBuf_.empty() && recvBuf_.front() != '$') {
-            recvBuf_.erase(recvBuf_.begin());
-            ++skipped;
-        }
-        if (skipped > 0) {
+        // ASCII '$'). Locate the next '$' with memchr and erase in one
+        // shot. std::vector::erase(begin()) shifts the whole tail, so
+        // byte-by-byte erasure would be O(n^2) in the amount of garbage.
+        if (recvBuf_.front() != '$') {
+            const void* found = std::memchr(recvBuf_.data(), '$', recvBuf_.size());
+            size_t skipped;
+            if (found == nullptr) {
+                skipped = recvBuf_.size();
+                recvBuf_.clear();
+            } else {
+                skipped = static_cast<size_t>(
+                    static_cast<const uint8_t*>(found) - recvBuf_.data());
+                recvBuf_.erase(recvBuf_.begin(),
+                               recvBuf_.begin() + skipped);
+            }
             NPLOGE << "TcpRtpClient: skipped " << skipped
                    << " non-frame bytes before next '$' (resync)";
         }
@@ -271,6 +289,21 @@ void TcpRtpClient::drainInterleavedBuffer()
             // RTCP (channels 1 and 3: sender reports etc.). Build an RR
             // in rtcpWriteBuf_; the outer loop in run() will write it after
             // the current perform returns.
+            //
+            // Only build an RR from a sender report. Anything shorter than
+            // an SR header (or from a non-SR packet type) we skip without
+            // reading the payload; reinterpret_casting a too-short buffer
+            // and then reading senderSSRC()/ntpTimestamp() would be an
+            // out-of-bounds read.
+            if (dataLen < sizeof(rtc::RtcpSr)) {
+                NPLOGD << "TcpRtpClient: ignoring short RTCP frame on channel "
+                       << static_cast<int>(channel) << " (" << dataLen
+                       << " bytes)";
+                recvBuf_.erase(recvBuf_.begin(),
+                               recvBuf_.begin() + frameTotal);
+                continue;
+            }
+
             const char* buffer = reinterpret_cast<const char*>(payload);
             auto sr = reinterpret_cast<const rtc::RtcpSr*>(buffer);
 

--- a/src/modules/rtsp-client/tcp_rtp_client.cpp
+++ b/src/modules/rtsp-client/tcp_rtp_client.cpp
@@ -177,14 +177,17 @@ void TcpRtpClient::run()
         }
         if (pendingRtcp) {
             ssize_t ret = ::write(sockfd, rtcpWriteBuf_, pendingRtcpLen);
-            if (ret < 0 || (size_t)ret < pendingRtcpLen) {
-                // RTCP RR is best-effort. A short write or transient
-                // EAGAIN/EINTR from SO_SNDTIMEO should not tear down the
-                // receive loop; if the connection is actually dead, recv()
-                // will surface it on the next iteration.
+            if (ret < 0) {
+                const int err = errno;
+                // RTCP RR is best-effort. A transient EAGAIN/EINTR from SO_SNDTIMEO
+                // should not tear down the receive loop; if the connection is actually
+                // dead, recv() will surface it on the next iteration.
                 NPLOGE << "Failed to write RTCP RR to TCP socket; dropping. ret: "
                        << ret << " expected: " << pendingRtcpLen
-                       << " errno: " << strerror(errno);
+                       << " errno: " << strerror(err);
+            } else if (static_cast<size_t>(ret) < pendingRtcpLen) {
+                NPLOGE << "Short write while sending RTCP RR to TCP socket; dropping. ret: "
+                       << ret << " expected: " << pendingRtcpLen;
             }
         }
     }

--- a/src/modules/rtsp-client/tcp_rtp_client.hpp
+++ b/src/modules/rtsp-client/tcp_rtp_client.hpp
@@ -6,6 +6,8 @@
 
 #include <util/util.hpp>
 
+#include <vector>
+
 
 namespace nabto {
 
@@ -40,10 +42,32 @@ public:
         curl_->stop();
     }
 
+    /**
+     * Install the libcurl interleave callback on the curl handle.
+     *
+     * This must be called BEFORE the PLAY request is performed, because
+     * many embedded RTSP servers (e.g. dolphin-rtsp-server on cheap IPC
+     * camera firmwares) start pushing interleaved RTP frames in the same
+     * send() as the PLAY response. With no INTERLEAVEFUNCTION installed,
+     * those frames are dropped/misrouted and libcurl's connection state
+     * desyncs against the camera. See SC-4605.
+     */
+    bool prepareInterleave();
+
     void run();
 
 private:
     static size_t rtp_write(void* ptr, size_t size, size_t nmemb, void* userp);
+
+    /// Drain complete `$<ch><be16-len><payload>` frames from recvBuf_,
+    /// dispatching each to the matching track. Tolerates partial frames
+    /// (leftover stays in recvBuf_) and concatenated frames (loop until
+    /// the buffer holds less than one complete frame).
+    void drainInterleavedBuffer();
+
+    /// Append incoming bytes to recvBuf_ and drain.
+    /// Caller does NOT hold mutex_.
+    void processIncomingBytes(const uint8_t* data, size_t len);
 
     CurlAsyncPtr curl_;
     std::string url_;
@@ -67,7 +91,14 @@ private:
     int audioDstPt_ = 0;
 
     char rtcpWriteBuf_[64];
+    size_t rtcpWriteLen_ = 0;  ///< total bytes to write incl. $<ch><len> header
     bool sendRtcp_ = false;
+
+    /// Byte buffer holding partially-received interleaved data between
+    /// libcurl callback invocations. libcurl's INTERLEAVEFUNCTION delivers
+    /// "whatever just arrived", not "exactly one frame", so we must
+    /// reassemble.
+    std::vector<uint8_t> recvBuf_;
 };
 
 


### PR DESCRIPTION
## Summary

Three commits fixing the RTSP TCP-interleaved video path. Tested against dolphin-rtsp-server on a cheap HEVC IPC camera; the iOS WebRTC client (`edge-ios-webrtc-decentral-auth`) now receives video instead of a black square.

- **rework RTSP TCP-interleaved transport** — install the libcurl interleave callback before PLAY so frames pushed in the same packet as the PLAY response are not dropped; replace the one-frame-per-callback assumption with a buffered framer; bypass `CURL_RTSPREQ_RECEIVE` and recv() directly on `CURLINFO_ACTIVESOCKET` so the read loop doesn't hang waiting for an RTSP response that never arrives; clear `O_NONBLOCK` and set `SO_RCVTIMEO`; htons() the RTCP RR framing length (was host-order, silently corrupted on every little-endian target).
- **fix SETUP URL construction** — `parseControlAttribute` concatenated Content-Base + relative control URL without a separating slash, producing SETUP URLs like `rtsp://host/live/maintrackID=0`. dolphin-rtsp-server returns 200 OK but never starts streaming. Bug has been present since 2023-12-20.
- **address Copilot review feedback on transport rework** — add `SO_SNDTIMEO` so the RTCP RR write() can't hang `stop()`; downgrade RTCP RR write failure from fatal to best-effort (RR is best-effort per RFC 3550); replace O(n^2) byte-at-a-time '\$' resync with memchr() + one batched erase; guard the `rtc::RtcpSr` reinterpret_cast on `dataLen >= sizeof(RtcpSr)` so a short/malformed interleaved RTCP frame can't OOB-read.

## Test plan

- [ ] Build via the existing CMake flow.
- [ ] Run `webrtc-demo` against a dolphin-rtsp-server HEVC camera and confirm video frames flow on the iOS client (no black square).
- [ ] Confirm graceful shutdown: tear down the iOS client mid-stream and verify the device-side TcpRtpClient thread exits within the `SO_RCVTIMEO` window (~500 ms).
- [ ] Sanity check against a VLC RTSP server (H.264) to make sure non-HEVC paths still work.